### PR TITLE
Various fixes, mostly around usage with CocoaPods

### DIFF
--- a/ios/ReactNativeHaptic.h
+++ b/ios/ReactNativeHaptic.h
@@ -8,7 +8,11 @@
  */
 
 #import <Foundation/Foundation.h>
-#import <RCTBridgeModule.h>
+#if __has_include(<React/RCTBridgeModule.h>)
+#import <React/RCTBridgeModule.h>
+#else
+#import "RCTBridgeModule.h"
+#endif
 
 @interface ReactNativeHaptic : NSObject<RCTBridgeModule>
 

--- a/ios/ReactNativeHaptic.h
+++ b/ios/ReactNativeHaptic.h
@@ -1,12 +1,3 @@
-/**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- */
-
 #import <Foundation/Foundation.h>
 #if __has_include(<React/RCTBridgeModule.h>)
 #import <React/RCTBridgeModule.h>

--- a/ios/ReactNativeHaptic.m
+++ b/ios/ReactNativeHaptic.m
@@ -14,11 +14,15 @@
 
 NSString* deviceName()
 {
-  struct utsname systemInfo;
-  uname(&systemInfo);
-  
-  return [NSString stringWithCString:systemInfo.machine
-                            encoding:NSUTF8StringEncoding];
+  static NSString *deviceName;
+  if (deviceName == nil) {
+    struct utsname systemInfo;
+    uname(&systemInfo);
+
+    deviceName = [NSString stringWithCString:systemInfo.machine
+                                    encoding:NSUTF8StringEncoding];
+  }
+  return deviceName;
 }
 
 @implementation ReactNativeHaptic

--- a/ios/ReactNativeHaptic.m
+++ b/ios/ReactNativeHaptic.m
@@ -1,12 +1,3 @@
-/**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- */
-
 #import "ReactNativeHaptic.h"
 #import <UIKit/UIKit.h>
 #import <AudioToolbox/AudioServices.h>

--- a/package.json
+++ b/package.json
@@ -1,23 +1,24 @@
 {
   "name": "react-native-haptic",
-  "version": "1.0.5",
-  "description": "iOS 10 + haptic feedback for React Native applications",
+  "version": "2.0.0",
+  "description": "iOS 10+ haptic feedback for React Native applications",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [
-    "react-native"
+    "react-native",
+    "haptic"
   ],
   "author": "Charles Vinette",
   "license": "MIT",
   "peerDependencies": {
-    "react-native": "^0.29.0",
-    "react": ">=15.4.0"
+    "react-native": ">= 0.29.0",
+    "react": ">= 15.4.0"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/charlesvinette/react-native-haptic.git"
+    "url": "https://github.com/charlesvinette/react-native-haptic.git"
   },
   "bugs": {
     "url": "https://github.com/charlesvinette/react-native-haptic/issues"

--- a/react-native-haptic.podspec
+++ b/react-native-haptic.podspec
@@ -1,13 +1,17 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
 Pod::Spec.new do |s|
-  s.name          = "react-native-haptic"
-  s.version       = "1.0.5"
-  s.source_files  = "ios/*.{h,m}"
-  s.platform      = :ios, "7.0"
-  s.authors       = "Charles Vinette"
-  s.license       = "MIT"
-  s.summary       = "iOS 10 + haptic feedback for React Native applications."
-  s.homepage      = "https://github.com/charlesvinette/react-native-haptic#readme"
-  s.source        = { :git => "https://github.com/charlesvinette/react-native-haptic.git" }
+  s.name          = package['name']
+  s.version       = package['version']
+  s.source_files  = 'ios/*.{h,m}'
+  s.platform      = :ios, '7.0'
+  s.authors       = package['author']
+  s.license       = package['license']
+  s.summary       = package['description']
+  s.homepage      = 'https://github.com/charlesvinette/react-native-haptic#readme'
+  s.source        = { :git => 'https://github.com/charlesvinette/react-native-haptic.git', tag: "v#{s.version}" }
 
   s.dependency 'React'
 end

--- a/react-native-haptic.podspec
+++ b/react-native-haptic.podspec
@@ -2,13 +2,12 @@ Pod::Spec.new do |s|
   s.name          = "react-native-haptic"
   s.version       = "1.0.5"
   s.source_files  = "ios/*.{h,m}"
-  s.ios.deployment_target = '10.0'
-  s.tvos.deployment_target = '10.0'
-  s.authors       = { "Charles Vinette" }
+  s.platform      = :ios, "7.0"
+  s.authors       = "Charles Vinette"
   s.license       = "MIT"
   s.summary       = "iOS 10 + haptic feedback for React Native applications."
   s.homepage      = "https://github.com/charlesvinette/react-native-haptic#readme"
-  s.source        = { :git => "git+https://github.com/charlesvinette/react-native-haptic.git" }
+  s.source        = { :git => "https://github.com/charlesvinette/react-native-haptic.git" }
 
   s.dependency 'React'
 end


### PR DESCRIPTION
While trying to install this package using CocoaPods, I encountered some issues.

The first was that the podspec wasn't valid, so that didn't work.

After fixing that I found that the imports being used in the objective-c header file couldn't resolve the files, that I fixed too.

And finally, to prevent some warnings about incorrect react(-native) version when npm-installing, I loosened the constraints for them in `package.json`. Nb. I'm not sure if the lower bound of this constraint is still compatible, but thought that as not being really important.