### PR TITLE
Support for Android, iOS vibration fallback, and default type

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add:
 ```xml
 <uses-permission android:name="android.permission.VIBRATE"/> 
 ```
-to the AndroidManifest.xml file.
+to the AndroidManifest.xml file. (/android/app/src/main)
 
 Source: https://facebook.github.io/react-native/docs/vibration
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@
 3. In XCode, in the project navigator, select your project. Add `libReactNativeHaptic.a` to your project's `Build Phases` ➜ `Link Binary With Libraries`
 4. Run your project (`Cmd+R`)<
 
+## For Android usage
+
+Add:
+```xml
+<uses-permission android:name="android.permission.VIBRATE"/> 
+```
+to the AndroidManifest.xml file.
+
+Source: https://facebook.github.io/react-native/docs/vibration
+
 ## How to use
 ```javascript  
   import ReactNativeHaptic from 'react-native-haptic';

--- a/index.js
+++ b/index.js
@@ -1,6 +1,46 @@
 
-import { NativeModules } from 'react-native';
+import { NativeModules, Platform, Vibration } from 'react-native';
 
-const { ReactNativeHaptic } = NativeModules;
+class ReactNativeHaptic {
+    static generate = (type = 'selection') => {
+        if (Platform.OS === "ios" && parseInt(Platform.Version, 10) >= 10) {
+            NativeModules.ReactNativeHaptic.generate(type)
+        } else {
+            if (Platform.OS === "android") {
+                switch (type) {
+                    case "selection":
+                        Vibration.vibrate(22)
+                        break;
+                    case "impactLight":
+                        Vibration.vibrate(25)
+                        break;
+                    case "impactMedium":
+                        Vibration.vibrate(30)
+                        break;
+                    case "impactHeavy":
+                        Vibration.vibrate(35)
+                        break;
+                    case "notification":
+                        Vibration.vibrate([10, 40, 60, 30])
+                        break;
+                    case "notificationSuccess":
+                        Vibration.vibrate([10, 75, 100, 40])
+                        break;
+                    case "notificationWarning":
+                        Vibration.vibrate([10, 30, 80, 40, 80, 50])
+                        break;
+                    case "notificationError":
+                        Vibration.vibrate([10, 40, 80, 30, 80, 50])
+                        break;
+                    default:
+                        Vibration.vibrate(22)
+                        break;
+                }
+            } else if (Platform.OS === "ios") {
+                Vibration.vibrate()
+            }
+        }
+    }
+}
 
 export default ReactNativeHaptic;

--- a/index.js
+++ b/index.js
@@ -2,23 +2,26 @@
 import { NativeModules, Platform, Vibration } from 'react-native';
 
 class ReactNativeHaptic {
+    // default type is 'selection' if no parameter is given
     static generate = (type = 'selection') => {
+        // checking if ios is greater than or equal to 10.0 (to utilize haptic engine)
         if (Platform.OS === "ios" && parseInt(Platform.Version, 10) >= 10) {
             NativeModules.ReactNativeHaptic.generate(type)
         } else {
+            // if platform is android, comparable vibration patterns based on type
             if (Platform.OS === "android") {
                 switch (type) {
                     case "selection":
                         Vibration.vibrate(22)
                         break;
                     case "impactLight":
-                        Vibration.vibrate(25)
-                        break;
-                    case "impactMedium":
                         Vibration.vibrate(30)
                         break;
+                    case "impactMedium":
+                        Vibration.vibrate(40)
+                        break;
                     case "impactHeavy":
-                        Vibration.vibrate(35)
+                        Vibration.vibrate(50)
                         break;
                     case "notification":
                         Vibration.vibrate([10, 40, 60, 30])
@@ -36,7 +39,8 @@ class ReactNativeHaptic {
                         Vibration.vibrate(22)
                         break;
                 }
-            } else if (Platform.OS === "ios") {
+                // vibration fallback for ios lower than 10.0
+            } else if (Platform.OS === "ios" && parseInt(Platform.Version, 10) < 10) {
                 Vibration.vibrate()
             }
         }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-
 import { NativeModules, Platform, Vibration } from 'react-native';
 
 class ReactNativeHaptic {


### PR DESCRIPTION
Added support for Android.
Vibration fallback for iOS < 10.0.
Default type is now 'selection'.

```
// these now both trigger selection
ReactNativeHaptic.generate()
ReactNativeHaptic.generate('selection')
```
Tested all methods on both iOS and Android physical devices, fully functional!